### PR TITLE
Fixes for new deployment

### DIFF
--- a/rest.py
+++ b/rest.py
@@ -92,7 +92,7 @@ class McM:
 
     def __generate_cookie(self):
         # use env to have a clean environment
-        command = 'rm -f %s; env -i auth-get-sso-cookie -u %s -o %s' % (self.cookie, self.server, self.cookie)
+        command = 'rm -f %s; env -i KRB5CCNAME="$KRB5CCNAME" auth-get-sso-cookie -u %s -o %s' % (self.cookie, self.server, self.cookie)
         self.logger.debug(command)
         output = os.popen(command).read()
         self.logger.debug(output)

--- a/rest.py
+++ b/rest.py
@@ -34,13 +34,11 @@ class MethodRequest(urllib.Request):
 
 
 class McM:
-    def __init__(self, id='sso', debug=False, cookie=None, dev=True, int=False):
+    def __init__(self, id='sso', debug=False, cookie=None, dev=True):
         if dev:
-            self.host = 'cms-pdmv-dev.cern.ch'
-        elif int:
-            self.host = 'cms-pdmv-int.cern.ch'
+            self.host = 'cms-pdmv-dev.web.cern.ch'
         else:
-            self.host = 'cms-pdmv.cern.ch'
+            self.host = 'cms-pdmv-prod.web.cern.ch'
 
         self.dev = dev
         self.server = 'https://' + self.host + '/mcm/'
@@ -57,8 +55,6 @@ class McM:
             home = os.getenv('HOME')
             if dev:
                 self.cookie = '%s/private/mcm-dev-cookie.txt' % (home)
-            elif int:
-                self.cookie = '%s/private/mcm-int-cookie.txt' % (home)
             else:
                 self.cookie = '%s/private/mcm-prod-cookie.txt' % (home)
 

--- a/rest.py
+++ b/rest.py
@@ -265,7 +265,14 @@ class McM:
         """
         res = self.__get('restapi/requests/soft_reset/%s' % (prepid))
         return res.get('results', None)
-    
+
+    def option_reset(self, prepid):
+        """
+        Option reset a request
+        """
+        res = self.__get('restapi/requests/option_reset/%s' % (prepid))
+        return res.get('results', None)
+
     def ticket_generate(self, ticket_prepid):
         """
         Generate chains for a ticket

--- a/rest.py
+++ b/rest.py
@@ -92,7 +92,7 @@ class McM:
 
     def __generate_cookie(self):
         # use env to have a clean environment
-        command = 'rm -f %s; env -i KRB5CCNAME="$KRB5CCNAME" cern-get-sso-cookie -u %s -o %s --reprocess --krb' % (self.cookie, self.server, self.cookie)
+        command = 'rm -f %s; env -i auth-get-sso-cookie -u %s -o %s' % (self.cookie, self.server, self.cookie)
         self.logger.debug(command)
         output = os.popen(command).read()
         self.logger.debug(output)


### PR DESCRIPTION
* Switch to `auth-get-sso-cookie`
* Update host names to avoid 30X responses for POST and PUT - see [this answer](https://stackoverflow.com/questions/62384020/python-3-7-urllib-request-doesnt-follow-redirect-url) and [RFC 2616](https://www.rfc-editor.org/rfc/rfc2616#section-10.3.2).

This also drops support for the long discontinued "integration" setup and commits the `option_reset` found on AFS but not on git.