### PR TITLE
Invalidate and delete requests in 'cascade'

### DIFF
--- a/invalidate_request.py
+++ b/invalidate_request.py
@@ -94,7 +94,7 @@ class InvalidateDeleteRequests:
         Returns:
             list[str]: Invalidations related to the requests.
         """
-        # 1. Flatten and just get the `_id` field
+        # Flatten and just get the `_id` field
         inv_ids: list[str] = [i.get("_id") for i in invalidations if i.get("_id")]
         announce_result = self.mcm.put(
             object_type="invalidations", object_data=inv_ids, method="announce"
@@ -384,7 +384,7 @@ class InvalidateDeleteRequests:
             )
 
         failed_requests: list[str] = []
-        sucess_requests: list[str] = []
+        success_requests: list[str] = []
         total_to_process = len(root_request_prepids)
         for idx, root_prepid in enumerate(root_request_prepids, start=1):
             try:
@@ -396,7 +396,7 @@ class InvalidateDeleteRequests:
                     remove_root=remove_root,
                     remove_chain=remove_chain,
                 )
-                sucess_requests.append(root_prepid)
+                success_requests.append(root_prepid)
             except Exception as e:
                 self.logger.error(
                     "Unable to process root request (%s): %s",
@@ -411,7 +411,7 @@ class InvalidateDeleteRequests:
                     break
 
         return {
-            "sucess": sucess_requests,
+            "success": success_requests,
             "failed": failed_requests,
             "filtered": discarded_prepids,
         }

--- a/invalidate_request.py
+++ b/invalidate_request.py
@@ -1,0 +1,417 @@
+"""
+This module allows to invalidate a 
+root requests and its generated chains.
+This is intended to be used only for
+`production_manager` users or `administrators`.
+"""
+
+# Add path to code that allow easy access to McM
+# sys.path.append("/afs/cern.ch/cms/PPD/PdmV/tools/McM/")
+
+import datetime
+import logging
+import pprint
+import sys
+from itertools import groupby
+from copy import deepcopy
+from rest import McM
+
+# Check if version is >= 3.11, otherwise raise an exception.
+if sys.version_info < (3, 11):
+    msg = (
+        "Unsuported Python version.\n"
+        "Please use a version equal of higher than Python 3.11.\n"
+        "Current version: %s " % (sys.version)
+    )
+    raise RuntimeError(msg)
+
+
+class InvalidateDeleteRequests:
+    """
+    Invalidate and delete all the chain requests in McM
+    linked to a root request in McM and delete the
+    root requests if required.
+    """
+
+    def __init__(self, mcm: McM) -> None:
+        self.mcm = mcm
+        self.logger = self._get_logger()
+        self._chain_request_type = "chained_requests"
+        self._request_type = "requests"
+        self.logger.warning("Sending requests to target environment: %s", self.mcm.host)
+
+    def _get_logger(self) -> logging.Logger:
+        """
+        Creates a logger to record the performed steps.
+        """
+        logger: logging.Logger = logging.getLogger(__name__)
+        formatter = logging.Formatter("[%(asctime)s][%(levelname)s] %(message)s")
+        current_date = str(datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"))
+        fh: logging.Handler = logging.FileHandler(
+            f"mcm_invalidate_requests_{current_date}.log"
+        )
+        fh.setFormatter(formatter)
+        logger.addHandler(fh)
+        return logger
+
+    def _pretty(self, obj: dict) -> str:
+        """
+        Pretty print an object in console
+        """
+        return pprint.pformat(obj, width=50, compact=True)
+
+    def _get(self, endpoint: str) -> dict:
+        """
+        Execute a raw GET operation for a resource in McM.
+        """
+        return self.mcm._McM__get(endpoint)
+
+    def _get_invalidations(self, requests: list[str]) -> list[dict]:
+        """
+        Get all the invalidation records related to request given by
+        parameter.
+
+        Args:
+            requests (list[str]): List of `prepids` used to retrieve its invalidations.
+
+        Returns:
+            list[str]: Invalidations related to the requests.
+        """
+        results: list[dict] = []
+        for req in requests:
+            inv_req = self.mcm.get("invalidations", query=f"prepid={req}")
+            results += inv_req
+
+        return results
+
+    def _announce_invalidations(self, invalidations: list[dict]) -> dict:
+        """
+        Announce an invalidation for the given invalidation records.
+
+        Args:
+            invalidations (list[dict]): List of `invalidation` records to announce.
+
+        Returns:
+            list[str]: Invalidations related to the requests.
+        """
+        # 1. Flatten and just get the `_id` field
+        inv_ids: list[str] = [i.get("_id") for i in invalidations if i.get("_id")]
+        announce_result = self.mcm.put(
+            object_type="invalidations", object_data=inv_ids, method="announce"
+        )
+
+        return announce_result
+
+    def _process_invalidation(self, request_prepids: list[str]) -> None:
+        """
+        Get all the invalidations related to a request and announces them
+        in case they exists.
+
+        Args:
+            requests (list[str]): List of request's prepid to process its
+                invalidation.
+        """
+        invalidations_to_announce = self._get_invalidations(requests=request_prepids)
+        if invalidations_to_announce:
+            announce_result = self._announce_invalidations(
+                invalidations=invalidations_to_announce
+            )
+            self.logger.info("Invalidation result: %s", announce_result)
+            if not announce_result.get("results"):
+                msg = f"Unable to invalidate records for all the following requests: {request_prepids}"
+                self.logger.error(msg)
+                self.logger.error("Invalidation records: %s", invalidations_to_announce)
+                raise RuntimeError(msg)
+        pass
+
+    def _invalidate_delete_chain_requests(
+        self, chain_req_data: list[dict], remove_chain: bool = False
+    ) -> None:
+        """
+        Rewinds the chain request to the root request
+        invalidating and deleting all the intermediate requests.
+        Deletes the chain request also if required.
+
+        Args:
+            chain_req_data (list[dict]): Chain requests data objects
+                to process.
+            remove_chain (bool): Deletes the chain request after
+                perform the invalidation. If False, the chain request
+                disable `flag` is re-enabled.
+        """
+        chain_req_operate: list[dict] = []
+        chain_request_only_with_root: list[dict] = []
+        chain_request_more_than_root: list[dict] = []
+
+        # Filter the chain requests that only have the root request.
+        for chain_request in chain_req_data:
+            if len(chain_request.get("chain")) == 1:
+                chain_request_only_with_root.append(chain_request)
+            else:
+                chain_request_more_than_root.append(chain_request)
+
+        # 1. Group the chained request by the second request in the chain
+        # (The first that is not the `root` request).
+        if chain_request_more_than_root:
+            grouped_chain = {
+                k: list(g)
+                for k, g in groupby(
+                    chain_request_more_than_root, lambda el: el["chain"][1]
+                )
+            }
+            if len(grouped_chain) != 1:
+                msg = f"There should be only one group. Group result: {grouped_chain}"
+                self.logger.error(msg)
+                raise ValueError(msg)
+
+            # Include in the list to operate.
+            chain_req_operate += list(grouped_chain.values())[0]
+
+        if chain_request_only_with_root:
+            only_prepids = [el.get("prepid") for el in chain_request_only_with_root]
+            self.logger.warning(
+                "The following chain request only contain the root request in its chain: %s",
+                self._pretty(only_prepids),
+            )
+            chain_req_operate += chain_request_only_with_root
+
+        # 2. Order the chain requests by `step` descending
+        chain_req_operate = sorted(
+            chain_req_operate, key=lambda el: el["step"], reverse=True
+        )
+        self.logger.info(
+            "Chain request pre-reset order (after sort): %s",
+            [el.get("prepid") for el in chain_req_operate],
+        )
+
+        # 3. Set the flag to `False` and save
+        for ch_r in chain_req_operate:
+            ch_req_prepid = ch_r.get("prepid")
+            updated_ch_r = self.mcm.get(
+                object_type=self._chain_request_type, object_id=ch_req_prepid
+            )
+            updated_ch_r["action_parameters"]["flag"] = False
+            updated_ch_r = self.mcm.update(
+                object_type=self._chain_request_type, object_data=updated_ch_r
+            )
+            self.logger.info("Disable 'flag' response: %s", updated_ch_r)
+
+            if not updated_ch_r or not updated_ch_r.get("results"):
+                msg = f"Error updating chain requests: {ch_req_prepid}"
+                self.logger.error(msg)
+                raise RuntimeError(msg)
+
+        for ch_r in chain_req_operate:
+            ch_req_prepid = ch_r.get("prepid")
+
+            # 4. Rewind the chain request to `root`.
+            rewind_endpoint = (
+                f"/restapi/chained_requests/rewind_to_root/{ch_req_prepid}"
+            )
+            rewind_response = self._get(endpoint=rewind_endpoint)
+            self.logger.info("Rewind chain request response: %s", rewind_response)
+            if not rewind_response or not rewind_response.get("results"):
+                msg = f"Unable to rewind chain request to root ({ch_r}) - Details: {rewind_response}"
+                self.logger.error(msg)
+                raise RuntimeError(msg)
+
+            # 5. Announce the invalidation.
+            ch_req_requests: list[str] = ch_r.get("chain")
+            self._process_invalidation(request_prepids=ch_r.get("chain"))
+
+            # 6. Delete the other requests EXCEPT for the `root`
+            # The first record in this list is the `root` request
+            chain_delete = ch_req_requests[1:]
+
+            # INFO: They must be deleted in order from the deepest
+            # data tier to upwards
+            chain_delete = reversed(chain_delete)
+
+            for rd in chain_delete:
+                self.mcm.delete(object_type=self._request_type, object_id=rd)
+
+        # 7. Process the chain request
+        if remove_chain:
+            # Precondition: All the chained request share the same
+            # root request.
+            root_request_prepid: str = chain_req_operate[0].get("chain", [])[0]
+            self.logger.warning(
+                "Full resetting the root request (%s) as it is required to properly delete the chains",
+                root_request_prepid,
+            )
+            result = self.mcm.reset(prepid=root_request_prepid)
+            if not result:
+                raise RuntimeError("Unable to reset the root request", result)
+
+            # Process the root request invalidation.
+            self._process_invalidation([root_request_prepid])
+
+            # Remove all the chain requests
+            for ch_r in chain_req_operate:
+                ch_req_prepid = ch_r.get("prepid")
+                self.mcm.delete(
+                    object_type=self._chain_request_type, object_id=ch_req_prepid
+                )
+        else:
+            # Re-enable the `flag`
+            for ch_r in chain_req_operate:
+                ch_req_prepid = ch_r.get("prepid")
+                updated_ch_r = self.mcm.get(
+                    object_type=self._chain_request_type, object_id=ch_req_prepid
+                )
+                updated_ch_r["action_parameters"]["flag"] = True
+                updated_ch_r = self.mcm.update(
+                    object_type=self._chain_request_type, object_data=updated_ch_r
+                )
+                self.logger.info("Disable 'flag' response: %s", updated_ch_r)
+                if not updated_ch_r or not updated_ch_r.get("results"):
+                    msg = f"Error updating chain requests: {ch_req_prepid}"
+                    self.logger.error(msg)
+                    raise RuntimeError(msg)
+
+    def _invalidate_delete_root_request(
+        self, root_prepid: str, remove_root: bool = False, remove_chain: bool = False
+    ) -> None:
+        """
+        Invalidates and deletes all the chained request
+        linked to a root request and remove the root
+        request if required.
+
+        Args:
+            root_prepid (str): Root request prepid
+            remove_root (bool): Invalidate and delete the root
+                request after processing its chains. If True,
+                the parameter `remove_chains` will be forced to
+                `True`
+            remove_chain (bool): Delete the chain request after
+                processing it. If False, the chained requests
+                `flag` is re-enabled.
+        """
+        self.logger.info(
+            "Processing root request: %s, remove root: %s, remove chains: %s",
+            root_prepid,
+            remove_root,
+            remove_chain,
+        )
+
+        if remove_root and not remove_chain:
+            self.logger.warning(
+                "Setting `remove_chain` to True as a cascade delete is requested"
+            )
+            remove_chain = True
+
+        if remove_chain:
+            self.logger.warning(
+                (
+                    "Root request will be FULL RESET "
+                    "and its output dataset will be invalidated! "
+                    "This is required to delete all its related chained requests."
+                )
+            )
+
+        # 1. Get all the chained requests and process them.
+        chain_req: list[dict] = self.mcm.get(
+            object_type=self._chain_request_type, query=f"contains={root_prepid}"
+        )
+        self.logger.info(
+            "Request (%s), operating chain requests: %s",
+            root_prepid,
+            self._pretty([ch.get("prepid") for ch in chain_req]),
+        )
+        self._invalidate_delete_chain_requests(
+            chain_req_data=chain_req, remove_chain=remove_chain
+        )
+
+        # 2. Remove the root request if required.
+        if remove_root:
+            self.mcm.delete(object_type=self._request_type, object_id=root_prepid)
+
+    def _filter_root_requests(self, requests_prepid: list[str]) -> list[str]:
+        """
+        Filter the given request's prepids and only pick
+        those related only to root requests.
+        """
+        root_requests: list[str] = []
+        for rid in requests_prepid:
+            data: dict | None = self.mcm.get(
+                object_type=self._request_type, object_id=rid
+            )
+            if data:
+                is_root_request: bool = (data.get("type") == "LHE") and bool(
+                    data.get("validation", {}).get("results", {})
+                )
+                if is_root_request:
+                    root_requests.append(rid)
+
+        return root_requests
+
+    def invalidate_delete_cascade_requests(
+        self,
+        requests_prepid: list[str],
+        remove_root: bool = False,
+        remove_chain: bool = False,
+        limit: int = 2**64,
+    ) -> dict[str, list[str]]:
+        """
+        Invalidate and delete all the request including into the
+        chain requests related to the provided root request.
+        This could be considered as a "delete in cascade" process.
+
+        Args:
+            requests_prepid (list[str]): List of root requests to process.
+                In case a non-root request is provided, it will be
+                filtered.
+            remove_root (bool): After processing the chained requests,
+                invalidate the dataset related to the root request and
+                delete it.
+            remove_chain (bool): After removing the intermediate requests,
+                remove the chain or re-enable it chain again.
+            limit (int): Process root requests until the limit is reached.
+
+        Returns:
+            dict[str, list[str]]: Details about the requests processed in
+                three categories: Success, Failed, Filtered.
+        """
+        root_request_prepids: list[str] = self._filter_root_requests(
+            requests_prepid=deepcopy(requests_prepid)
+        )
+        discarded_prepids = list(set(requests_prepid) - set(root_request_prepids))
+        if discarded_prepids:
+            self.logger.info(
+                "Following requests are not valid root requests (%s): %s",
+                len(discarded_prepids),
+                self._pretty(discarded_prepids),
+            )
+
+        failed_requests: list[str] = []
+        sucess_requests: list[str] = []
+        total_to_process = len(root_request_prepids)
+        for idx, root_prepid in enumerate(root_request_prepids, start=1):
+            try:
+                self.logger.info(
+                    "(%s/%s) Processing root request", idx, total_to_process
+                )
+                self._invalidate_delete_root_request(
+                    root_prepid=root_prepid,
+                    remove_root=remove_root,
+                    remove_chain=remove_chain,
+                )
+                sucess_requests.append(root_prepid)
+            except Exception as e:
+                self.logger.error(
+                    "Unable to process root request (%s): %s",
+                    root_prepid,
+                    e,
+                    exc_info=True,
+                )
+                failed_requests.append(root_prepid)
+            finally:
+                if limit <= idx:
+                    self.logger.info("Early stopping processing root requests...")
+                    break
+
+        return {
+            "sucess": sucess_requests,
+            "failed": failed_requests,
+            "filtered": discarded_prepids,
+        }

--- a/invalidate_request_test.py
+++ b/invalidate_request_test.py
@@ -75,7 +75,7 @@ class InvalidateDeleteRequestTest(unittest.TestCase):
         result = self.invalidator.invalidate_delete_cascade_requests(
             requests_prepid=non_root_req
         )
-        self.assertEqual(result.get("sucess"), [], "No request should be processed")
+        self.assertEqual(result.get("success"), [], "No request should be processed")
         self.assertEqual(result.get("failed"), [], "No request should be processed")
         self.assertEqual(
             set(result.get("filtered")),
@@ -93,7 +93,7 @@ class InvalidateDeleteRequestTest(unittest.TestCase):
         result = self.invalidator.invalidate_delete_cascade_requests(
             requests_prepid=non_exists
         )
-        self.assertEqual(result.get("sucess"), [], "No request should be processed")
+        self.assertEqual(result.get("success"), [], "No request should be processed")
         self.assertEqual(result.get("failed"), [], "No request should be processed")
         self.assertEqual(
             set(result.get("filtered")),
@@ -118,7 +118,7 @@ class InvalidateDeleteRequestTest(unittest.TestCase):
 
         # Check it was properly processed.
         self.assertEqual(
-            result.get("sucess"),
+            result.get("success"),
             [example_root_request_prepid],
             "The example request should be processed properly",
         )
@@ -166,7 +166,7 @@ class InvalidateDeleteRequestTest(unittest.TestCase):
 
         # Check it was properly processed.
         self.assertEqual(
-            result.get("sucess"),
+            result.get("success"),
             [example_root_request_prepid],
             "The example request should be processed properly",
         )

--- a/invalidate_request_test.py
+++ b/invalidate_request_test.py
@@ -1,0 +1,240 @@
+"""
+This module tests the functionality
+provided in the `invalidate_request.py`
+module to delete requests in cascade.
+"""
+
+import unittest
+import os
+import random
+from rest import McM
+from invalidate_request import InvalidateDeleteRequests
+
+
+class InvalidateDeleteRequestTest(unittest.TestCase):
+    """
+    Test cases for the class `InvalidateDeleteRequests`.
+    """
+
+    # Some McM types required to query.
+    chain_request_type = "chained_requests"
+    request_type = "requests"
+
+    def _remove_cookies(self):
+        """
+        This tries to remove the session cookies if they are
+        available in the filesystem.
+        """
+        home = os.getenv("HOME")
+        dev_cookie_path = "%s/private/mcm-dev-cookie.txt" % (home)
+        try:
+            os.remove(dev_cookie_path)
+        except OSError:
+            # Supress the error if some file doesn't exist
+            pass
+
+    def _get_test_request(self, mcm: McM, size: int) -> list[str]:
+        """
+        Get some example requests to use in the tests.
+        Return only its prepid.
+        Raises an error if it is not possible to retrieve
+        this test set.
+        """
+        samples = mcm.get(
+            object_type=InvalidateDeleteRequestTest.request_type,
+            query="prepid=*Run3Summer22*GS*&status=done",
+            page=2,
+        )
+        random.shuffle(samples)
+        if not samples:
+            raise ValueError("Unable to retrieve a test set.")
+
+        return [
+            el.get("prepid") for idx, el in enumerate(samples, start=1) if idx <= size
+        ]
+
+    def setUp(self) -> None:
+        """
+        Build the test environment.
+        """
+        self._remove_cookies()
+        self.mcm = McM(id=McM.SSO, dev=True)
+        self.samples = self._get_test_request(mcm=self.mcm, size=5)
+        self.invalidator = InvalidateDeleteRequests(mcm=self.mcm)
+
+    def test_non_root_requests(self) -> None:
+        """
+        Check that non root requests are processed.
+        """
+        non_root_req = [
+            "B2G-Run3Summer19MiniAOD-00012",
+            "B2G-Run3Summer19NanoAOD-00012",
+            "B2G-Run3Summer19DRPremix-00001",
+            "B2G-Run3Summer19DR-00006",
+        ]
+        result = self.invalidator.invalidate_delete_cascade_requests(
+            requests_prepid=non_root_req
+        )
+        self.assertEqual(result.get("sucess"), [], "No request should be processed")
+        self.assertEqual(result.get("failed"), [], "No request should be processed")
+        self.assertEqual(
+            set(result.get("filtered")),
+            set(non_root_req),
+            "All request should be filtered out",
+        )
+
+    def test_root_request_not_exists(self) -> None:
+        """
+        Check that the procedure fails gracefully
+        if it is attempted to process a root requests
+        that doesn't exists.
+        """
+        non_exists = ["PPD-Run3HeheNotExists23pLHEGS-00001"]
+        result = self.invalidator.invalidate_delete_cascade_requests(
+            requests_prepid=non_exists
+        )
+        self.assertEqual(result.get("sucess"), [], "No request should be processed")
+        self.assertEqual(result.get("failed"), [], "No request should be processed")
+        self.assertEqual(
+            set(result.get("filtered")),
+            set(non_exists),
+            "All request should be filtered out",
+        )
+
+    def test_renable_chain_request(self) -> None:
+        """
+        Deletes all the intermediate request for all the
+        chained request included into a root request
+        without removing the chain request after processing.
+        """
+        example_root_request_prepid = self.samples[0]
+        example_chain_requests: list[str] = self.mcm.get(
+            object_type=InvalidateDeleteRequestTest.request_type,
+            object_id=example_root_request_prepid,
+        ).get("member_of_chain", [])
+        result = self.invalidator.invalidate_delete_cascade_requests(
+            requests_prepid=[example_root_request_prepid]
+        )
+
+        # Check it was properly processed.
+        self.assertEqual(
+            result.get("sucess"),
+            [example_root_request_prepid],
+            "The example request should be processed properly",
+        )
+
+        # Check the chain requests still exists.
+        validation_chain_request: list[str] = self.mcm.get(
+            object_type="requests", object_id=example_root_request_prepid
+        ).get("member_of_chain", [])
+        self.assertEqual(
+            set(example_chain_requests),
+            set(validation_chain_request),
+            "No chain request should be deleted",
+        )
+
+        # Check each chain request.
+        for chain_prepid in validation_chain_request:
+            chain_request_data: dict = self.mcm.get(
+                object_type=InvalidateDeleteRequestTest.chain_request_type,
+                object_id=chain_prepid,
+            )
+            self.assertEqual(
+                chain_request_data.get("action_parameters", {}).get("flag"),
+                True,
+                "Flag should be set again",
+            )
+            self.assertEqual(
+                set(chain_request_data.get("chain", [])),
+                set([example_root_request_prepid]),
+                "The chain request contains more elements than the root request",
+            )
+
+    def test_delete_chain_request_non_root(self) -> None:
+        """
+        Deletes all the chain requests related to
+        a root request and its intermediate requests.
+        """
+        example_root_request_prepid = self.samples[0]
+        example_chain_requests: list[str] = self.mcm.get(
+            object_type=InvalidateDeleteRequestTest.request_type,
+            object_id=example_root_request_prepid,
+        ).get("member_of_chain", [])
+        result = self.invalidator.invalidate_delete_cascade_requests(
+            requests_prepid=[example_root_request_prepid], remove_chain=True
+        )
+
+        # Check it was properly processed.
+        self.assertEqual(
+            result.get("sucess"),
+            [example_root_request_prepid],
+            "The example request should be processed properly",
+        )
+
+        # Check that the chains shouldn't exist anymore.
+        validation_root_request: dict = self.mcm.get(
+            object_type="requests", object_id=example_root_request_prepid
+        )
+        self.assertIsNotNone(
+            validation_root_request, "The root request should be deleted"
+        )
+
+        validation_chain_request: list[str] = validation_root_request.get(
+            "member_of_chain", []
+        )
+        self.assertEqual(
+            [],
+            validation_chain_request,
+            "No chain request should appear here.",
+        )
+
+        deleted_chain_request: list[None] = [
+            self.mcm.get(
+                object_type=InvalidateDeleteRequestTest.chain_request_type,
+                object_id=deleted_chain,
+            )
+            for deleted_chain in example_chain_requests
+        ]
+        self.assertEqual(
+            any(deleted_chain_request), False, "No chain request should exist anymore"
+        )
+
+    def test_delete_all_from_root(self) -> None:
+        """
+        Invalidate and delete a root request and all the requests
+        and chain requests linked to it.
+        """
+        example_root_request_prepid = self.samples[0]
+        root_request_data: dict = self.mcm.get(
+            object_type=InvalidateDeleteRequestTest.request_type,
+            object_id=example_root_request_prepid,
+        )
+        linked_chained_requests: list[str] = root_request_data.get(
+            "member_of_chain", []
+        )
+
+        # Prune the root request.
+        self.invalidator.invalidate_delete_cascade_requests(
+            requests_prepid=[example_root_request_prepid], remove_root=True
+        )
+
+        # The root request shouldn't exists anymore.
+        root_request_data: dict = self.mcm.get(
+            object_type=InvalidateDeleteRequestTest.request_type,
+            object_id=example_root_request_prepid,
+        )
+        self.assertIsNone(root_request_data, "Root request shouldn't exist anymore")
+
+        # Check all the old chained request don't exists anymore.
+        for chain_request in linked_chained_requests:
+            chain_request_data = self.mcm.get(
+                object_type=InvalidateDeleteRequestTest.chain_request_type,
+                object_id=chain_request,
+            )
+            self.assertIsNone(
+                chain_request_data, "Chained request shouldn't exist anymore"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The following module allows users with `production_manager` or `administrator` permissions to delete and invalidate in cascade all the requests included into a chained request linked to a root one. Also, it allows the deletion of the chained requests and root request records if required. 

This is the result of completing: [PDMVDEV-113](https://its.cern.ch/jira/projects/PDMVDEV/issues/PDMVDEV-113)
Tests are provided to check the correctness.