### PR TITLE
Request a session cookie from scratch

### DIFF
--- a/src/rest/client/auth/handlers/session_cookies.py
+++ b/src/rest/client/auth/handlers/session_cookies.py
@@ -41,6 +41,9 @@ class SessionCookieHandler(AuthInterface):
             return None
 
     def _request_credential(self) -> MozillaCookieJar:
+        # Remove the cookie file in case there's available
+        self._credential_path.unlink(missing_ok=True)
+
         # Request a session cookie using CERN internal packages.
         command = (
             f"auth-get-sso-cookie -u '{self._url}' -o '{str(self._credential_path)}'"

--- a/src/rest/client/session.py
+++ b/src/rest/client/session.py
@@ -26,7 +26,7 @@ class AuthenticatedSession(requests.Session):
         self, method: Union[str, bytes], url: Union[str, bytes], *args, **kwargs
     ) -> requests.Response:
         response = super().request(method, url, *args, **kwargs)
-        for attempt in enumerate(range(self._max_attempts), start=1):
+        for attempt, _ in enumerate(range(self._max_attempts), start=1):
             if self._handler.validate_response(response):
                 return response
             else:


### PR DESCRIPTION
1. Remove a cookie's file before requesting a new one in case it exists.

- Avoid issues with the underlying package `auth-get-sso-cookie`. Sometimes, the package rejects to request for a new
session asking the user to reuse the same Keycloak session because it is still valid. This will raise a `RuntimeError`
that will stop the user's code execution. Just suppress this behavior by deleting the current file if exists and requesting
a new session cookie.

2. Fix logging typo.

- A `tuple` was recorded in the log, fix this to just record the current attempt (`int`).