### PR TITLE
Duplicate log messages

### DIFF
--- a/src/rest/applications/base.py
+++ b/src/rest/applications/base.py
@@ -78,7 +78,6 @@ class BaseClient:
         self._client_secret = client_secret
         
         self.logger = LoggerFactory.getLogger(f"pdmv-http-client.{self._app}")
-        self.credentials_path = self._credentials_path()
         self.server = self._target_web_application()
         self.credentials_path = self._credentials_path()
         self.session = self._create_session()

--- a/src/rest/applications/mcm/invalidate_request.py
+++ b/src/rest/applications/mcm/invalidate_request.py
@@ -36,8 +36,9 @@ class InvalidateDeleteRequests:
         Creates a logger to record the performed steps.
         """
         logger: logging.Logger = logging.getLogger(__name__)
+        logger.handlers.clear() # Avoid to record the same message twice in the log
         formatter = logging.Formatter("[%(asctime)s][%(levelname)s] %(message)s")
-        current_date = str(datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"))
+        current_date = str(datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S"))
         fh: logging.Handler = logging.FileHandler(
             f"mcm_invalidate_requests_{current_date}.log"
         )


### PR DESCRIPTION
Related to: #23

1. Avoid recording the same event twice in the log file for the invalidator component.
2. Avoid reloading the credential's path twice