### PR TITLE
Move old `mangled` methods back to the McM class

### DIFF
--- a/src/rest/applications/base.py
+++ b/src/rest/applications/base.py
@@ -5,7 +5,6 @@ object for PdmV applications.
 """
 
 import os
-import warnings
 from pathlib import Path
 from typing import Union
 
@@ -76,7 +75,7 @@ class BaseClient:
         self._dev = dev
         self._client_id = client_id
         self._client_secret = client_secret
-        
+
         self.logger = LoggerFactory.getLogger(f"pdmv-http-client.{self._app}")
         self.server = self._target_web_application()
         self.credentials_path = self._credentials_path()
@@ -168,38 +167,6 @@ class BaseClient:
 
     def __repr__(self):
         return f"<HTTP client (For: {self._app}) id: {self._id} server: {self.server} cookie: {self._cookie}>"
-
-    def __get(self, url):
-        warnings.warn(
-            "This name mangled method will be removed in the future, use self._get(...) instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._get(url=url)
-
-    def __put(self, url, data):
-        warnings.warn(
-            "This name mangled method will be removed in the future, use self._put(...) instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._put(url=url, data=data)
-
-    def __post(self, url, data):
-        warnings.warn(
-            "This name mangled method will be removed in the future, use self._post(...) instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._post(url=url, data=data)
-
-    def __delete(self, url):
-        warnings.warn(
-            "This name mangled method will be removed in the future, use self._delete(...) instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._delete(url=url)
 
     def _get(self, url: str):
         """

--- a/src/rest/applications/mcm/core.py
+++ b/src/rest/applications/mcm/core.py
@@ -2,7 +2,9 @@
 REST client for the McM application.
 """
 
+import warnings
 from typing import Union
+
 from rest.applications.base import BaseClient
 
 
@@ -30,6 +32,38 @@ class McM(BaseClient):
             client_id=client_id,
             client_secret=client_secret,
         )
+
+    def __get(self, url):
+        warnings.warn(
+            "This name mangled method will be removed in the future, use self._get(...) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._get(url=url)
+
+    def __put(self, url, data):
+        warnings.warn(
+            "This name mangled method will be removed in the future, use self._put(...) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._put(url=url, data=data)
+
+    def __post(self, url, data):
+        warnings.warn(
+            "This name mangled method will be removed in the future, use self._post(...) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._post(url=url, data=data)
+
+    def __delete(self, url):
+        warnings.warn(
+            "This name mangled method will be removed in the future, use self._delete(...) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._delete(url=url)
 
     # McM methods
     def get(self, object_type, object_id=None, query="", method="get", page=-1):


### PR DESCRIPTION
Introduced by: [#28](https://github.com/cms-PdmV/mcm_scripts/pull/28)

The current behavior changed the access to reference the `BaseClient` class. Move these methods back again to the `McM` class so that compatibility is kept the same as the old client version.